### PR TITLE
feat: add task prioritization

### DIFF
--- a/DEVELOPMENT_PLAN_MVP.md
+++ b/DEVELOPMENT_PLAN_MVP.md
@@ -99,11 +99,11 @@
 
 **Branch: `feat/prioritization`**
 
-- [ ] PRIO-1: Extend Todo model with priority levels
-- [ ] PRIO-2: Write tests for priority features
-- [ ] PRIO-3: Implement priority selector in forms
-- [ ] PRIO-4: Implement priority display in TodoItem
-- [ ] PRIO-5: Implement sorting by priority
+- [x] PRIO-1: Write tests for priority features (add, edit, sort)
+- [x] PRIO-2: Extend Todo model with priority levels
+- [x] PRIO-3: Implement sorting by priority (in store)
+- [ ] PRIO-4: Implement priority selector in forms
+- [ ] PRIO-5: Implement priority display in TodoItem
 - [ ] PRIO-6: Create PR `feat/prioritization` → `dev`
 
 **Branch: `feat/advanced-filtering`**

--- a/DEVELOPMENT_PLAN_MVP.md
+++ b/DEVELOPMENT_PLAN_MVP.md
@@ -102,8 +102,9 @@
 - [x] PRIO-1: Write tests for priority features (add, edit, sort)
 - [x] PRIO-2: Extend Todo model with priority levels
 - [x] PRIO-3: Implement sorting by priority (in store)
-- [ ] PRIO-4: Implement priority selector in forms
+- [x] PRIO-4: Implement priority selector in forms
 - [ ] PRIO-5: Implement priority display in TodoItem
+- [ ] PRIO-STORY: Create/Update Storybook stories for AddTodoForm & TodoItem
 - [ ] PRIO-6: Create PR `feat/prioritization` → `dev`
 
 **Branch: `feat/advanced-filtering`**

--- a/DEVELOPMENT_PLAN_MVP.md
+++ b/DEVELOPMENT_PLAN_MVP.md
@@ -104,7 +104,7 @@
 - [x] PRIO-3: Implement sorting by priority (in store)
 - [x] PRIO-4: Implement priority selector in forms
 - [x] PRIO-5: Implement priority display in TodoItem
-- [ ] PRIO-STORY: Create/Update Storybook stories for AddTodoForm & TodoItem
+- [x] PRIO-STORY: Create/Update Storybook stories for AddTodoForm & TodoItem
 - [ ] PRIO-6: Create PR `feat/prioritization` → `dev`
 
 **Branch: `feat/advanced-filtering`**

--- a/DEVELOPMENT_PLAN_MVP.md
+++ b/DEVELOPMENT_PLAN_MVP.md
@@ -103,7 +103,7 @@
 - [x] PRIO-2: Extend Todo model with priority levels
 - [x] PRIO-3: Implement sorting by priority (in store)
 - [x] PRIO-4: Implement priority selector in forms
-- [ ] PRIO-5: Implement priority display in TodoItem
+- [x] PRIO-5: Implement priority display in TodoItem
 - [ ] PRIO-STORY: Create/Update Storybook stories for AddTodoForm & TodoItem
 - [ ] PRIO-6: Create PR `feat/prioritization` → `dev`
 

--- a/src/components/AddTodoForm.stories.tsx
+++ b/src/components/AddTodoForm.stories.tsx
@@ -16,7 +16,8 @@ const meta = {
 		layout: 'centered',
 		docs: {
 			description: {
-				component: 'Form for adding new todos with validation and submission handling',
+				component:
+					'Form for adding new todos with title input and priority selection (defaults to medium). Handles validation and submission.',
 			},
 		},
 	},

--- a/src/components/AddTodoForm.tsx
+++ b/src/components/AddTodoForm.tsx
@@ -1,31 +1,45 @@
 import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { AddTodoFormProps } from '@/types/todoTypes';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { AddTodoFormProps, CreateTodoParams, PriorityLevel } from '@/types/todoTypes';
 
 /**
- * A form component for adding new todos
+ * A form component for adding new todos, including priority selection.
  */
 export function AddTodoForm({ onAddTodo }: AddTodoFormProps) {
 	const [title, setTitle] = useState('');
+	const [priority, setPriority] = useState<PriorityLevel>('medium');
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 
-		// Don't submit if the title is empty
 		if (!title.trim()) return;
 
-		// Call the callback with the new todo
-		onAddTodo({ title });
+		const newTodoParams: CreateTodoParams = {
+			title: title.trim(),
+			priority: priority,
+		};
 
-		// Clear the input field
+		onAddTodo(newTodoParams);
+
 		setTitle('');
+		setPriority('medium');
 	};
+
+	const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
 	return (
 		<form
 			onSubmit={handleSubmit}
-			className="flex gap-2 mb-4"
+			className="flex items-center gap-2 mb-4"
 			aria-label="Add todo form"
 			role="form"
 		>
@@ -37,7 +51,27 @@ export function AddTodoForm({ onAddTodo }: AddTodoFormProps) {
 				className="flex-1 text-sm px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
 				aria-label="Todo title"
 			/>
-			<Button type="submit" variant="default">
+
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="outline" className="flex items-center gap-1 px-3">
+						{capitalize(priority)}
+						<ChevronDown className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent className="w-40">
+					<DropdownMenuRadioGroup
+						value={priority}
+						onValueChange={(value: string) => setPriority(value as PriorityLevel)}
+					>
+						<DropdownMenuRadioItem value="low">Low</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem value="medium">Medium</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem value="high">High</DropdownMenuRadioItem>
+					</DropdownMenuRadioGroup>
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<Button type="submit" variant="default" className="px-4">
 				Add
 			</Button>
 		</form>

--- a/src/components/TodoItem.stories.tsx
+++ b/src/components/TodoItem.stories.tsx
@@ -35,6 +35,7 @@ export const Default: Story = {
 			completed: false,
 			description: 'This is a default todo item',
 			dueDate: undefined,
+			priority: 'medium',
 		},
 	},
 };
@@ -47,6 +48,7 @@ export const Completed: Story = {
 			completed: true,
 			description: 'This task is done!',
 			dueDate: new Date().toISOString(),
+			priority: 'low',
 		},
 	},
 };
@@ -93,6 +95,7 @@ export const Interactive: Story = {
 			title: 'Interactive Todo',
 			completed: false,
 			description: 'Try editing me!',
+			priority: 'high',
 		},
 		// onSave, onToggle, onDelete handlers are provided by the default meta args
 	},

--- a/src/components/TodoItem.stories.tsx
+++ b/src/components/TodoItem.stories.tsx
@@ -53,6 +53,17 @@ export const Completed: Story = {
 	},
 };
 
+export const Minimal: Story = {
+	args: {
+		todo: {
+			id: '4',
+			title: 'Minimal Todo (No Desc/Date)',
+			completed: false,
+			priority: 'medium',
+		},
+	},
+};
+
 export const Interactive: Story = {
 	render: args => {
 		// Use state within the render function for interactivity specific to this story

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -4,12 +4,21 @@ import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 import { EditTodoForm } from './EditTodoForm';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { PriorityLevel, Todo, TodoItemProps } from '@/types/todoTypes';
 
-const priorityVariantMap: Record<PriorityLevel, 'destructive' | 'outline' | 'secondary'> = {
-	high: 'destructive',
-	medium: 'outline',
-	low: 'secondary',
+// Helper function to get badge classes based on priority
+const getPriorityBadgeClasses = (priority: PriorityLevel): string => {
+	switch (priority) {
+		case 'high':
+			return 'border-transparent bg-red-100 text-red-700 hover:bg-red-100/80'; // Subtle red
+		case 'medium':
+			return 'border-transparent bg-yellow-100 text-yellow-700 hover:bg-yellow-100/80'; // Subtle yellow
+		case 'low':
+			return 'border-transparent bg-blue-100 text-blue-700 hover:bg-blue-100/80'; // Subtle blue
+		default:
+			return 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80'; // Default like secondary
+	}
 };
 
 /**
@@ -42,7 +51,7 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 
 	return (
 		<li
-			className="py-2 flex flex-col gap-1 border-b border-gray-100 last:border-0"
+			className="py-2 flex flex-col gap-1 border-b border-gray-100 last:border-0 hover:bg-muted/50 transition-colors duration-150"
 			aria-labelledby={`todo-title-${todo.id}`}
 			role="listitem"
 		>
@@ -50,7 +59,7 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 				<EditTodoForm initialData={todo} onSave={handleSave} onCancel={handleCancel} />
 			) : (
 				// Display mode
-				<div className="flex items-center gap-2 w-full">
+				<div className="flex items-center gap-2 w-full px-2">
 					<input
 						type="checkbox"
 						checked={todo.completed}
@@ -58,11 +67,11 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 						className="h-4 w-4 text-primary border-gray-300 rounded focus:ring-2 focus:ring-primary"
 						aria-labelledby={`todo-title-${todo.id}`}
 					/>
-					<div className="flex-1 flex flex-col text-sm">
+					<div className="flex-1 flex flex-col text-sm py-1">
 						<div className="flex items-center gap-2">
-							{' '}
-							{/* Wrapper for title and badge */}
-							<Badge variant={priorityVariantMap[todo.priority]} className="px-1.5 py-0.5 text-xs">
+							<Badge
+								className={`px-1.5 py-0.5 text-xs font-medium ${getPriorityBadgeClasses(todo.priority)}`}
+							>
 								{todo.priority}
 							</Badge>
 							<span
@@ -74,31 +83,35 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 						</div>
 						{/* Display description if it exists */}
 						{todo.description && (
-							<span className="text-xs text-gray-600 mt-1">{todo.description}</span>
+							<span className="text-xs text-muted-foreground mt-1">{todo.description}</span>
 						)}
 						{/* Display due date if it exists */}
 						{todo.dueDate && (
-							<span className="text-xs text-gray-500 mt-1">
+							<span className="text-xs text-muted-foreground mt-1">
 								Due: {new Date(todo.dueDate).toLocaleDateString()}
 							</span>
 						)}
 					</div>
 					{/* Action Buttons in display mode */}
-					<div className="flex items-center gap-2">
-						<button
+					<div className="flex items-center">
+						<Button
+							variant="ghost"
+							size="icon"
 							onClick={handleEdit}
-							className="text-blue-500 hover:text-blue-700 focus:outline-none p-1"
 							aria-label={`Edit todo: ${todo.title}`}
+							className="h-7 w-7 text-muted-foreground hover:text-blue-600"
 						>
 							<FaEdit className="h-4 w-4" />
-						</button>
-						<button
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
 							onClick={handleDelete}
-							className="text-red-500 hover:text-red-700 focus:outline-none p-1"
 							aria-label={`Delete todo: ${todo.title}`}
+							className="h-7 w-7 text-muted-foreground hover:text-red-600"
 						>
 							<FaTrashAlt className="h-4 w-4" />
-						</button>
+						</Button>
 					</div>
 				</div>
 			)}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,8 +1,16 @@
 import { useState } from 'react';
+import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 
 import { EditTodoForm } from './EditTodoForm';
 
-import { Todo, TodoItemProps } from '@/types/todoTypes';
+import { Badge } from '@/components/ui/badge';
+import { PriorityLevel, Todo, TodoItemProps } from '@/types/todoTypes';
+
+const priorityVariantMap: Record<PriorityLevel, 'destructive' | 'outline' | 'secondary'> = {
+	high: 'destructive',
+	medium: 'outline',
+	low: 'secondary',
+};
 
 /**
  * A component that renders a single todo item with checkbox, edit and delete buttons.
@@ -39,11 +47,7 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 			role="listitem"
 		>
 			{isEditing ? (
-				<EditTodoForm
-					initialData={todo} // Pass the whole todo or necessary fields
-					onSave={handleSave} // Pass the wrapper save handler
-					onCancel={handleCancel} // Pass the cancel handler
-				/>
+				<EditTodoForm initialData={todo} onSave={handleSave} onCancel={handleCancel} />
 			) : (
 				// Display mode
 				<div className="flex items-center gap-2 w-full">
@@ -55,12 +59,19 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 						aria-labelledby={`todo-title-${todo.id}`}
 					/>
 					<div className="flex-1 flex flex-col text-sm">
-						<span
-							id={`todo-title-${todo.id}`}
-							className={`${todo.completed ? 'text-gray-500 line-through' : ''}`}
-						>
-							{todo.title}
-						</span>
+						<div className="flex items-center gap-2">
+							{' '}
+							{/* Wrapper for title and badge */}
+							<Badge variant={priorityVariantMap[todo.priority]} className="px-1.5 py-0.5 text-xs">
+								{todo.priority}
+							</Badge>
+							<span
+								id={`todo-title-${todo.id}`}
+								className={`${todo.completed ? 'text-gray-500 line-through' : ''}`}
+							>
+								{todo.title}
+							</span>
+						</div>
 						{/* Display description if it exists */}
 						{todo.description && (
 							<span className="text-xs text-gray-600 mt-1">{todo.description}</span>
@@ -76,40 +87,17 @@ export function TodoItem({ todo, onToggle, onDelete, onSave }: TodoItemProps) {
 					<div className="flex items-center gap-2">
 						<button
 							onClick={handleEdit}
-							className="text-blue-500 hover:text-blue-700 focus:outline-none"
+							className="text-blue-500 hover:text-blue-700 focus:outline-none p-1"
 							aria-label={`Edit todo: ${todo.title}`}
 						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								className="h-5 w-5"
-								viewBox="0 0 20 20"
-								fill="currentColor"
-							>
-								<path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" />
-								<path
-									fillRule="evenodd"
-									d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"
-									clipRule="evenodd"
-								/>
-							</svg>
+							<FaEdit className="h-4 w-4" />
 						</button>
 						<button
 							onClick={handleDelete}
-							className="text-red-500 hover:text-red-700 focus:outline-none"
+							className="text-red-500 hover:text-red-700 focus:outline-none p-1"
 							aria-label={`Delete todo: ${todo.title}`}
 						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								className="h-5 w-5"
-								viewBox="0 0 20 20"
-								fill="currentColor"
-							>
-								<path
-									fillRule="evenodd"
-									d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-									clipRule="evenodd"
-								/>
-							</svg>
+							<FaTrashAlt className="h-4 w-4" />
 						</button>
 					</div>
 				</div>

--- a/src/components/TodoList.stories.tsx
+++ b/src/components/TodoList.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { Decorator } from '@storybook/react';
 import { fn } from '@storybook/test';
@@ -64,31 +65,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const mockTodos: Todo[] = [
-	{ id: '1', title: 'Learn Storybook', completed: false },
-	{ id: '2', title: 'Write stories', completed: true },
-	{ id: '3', title: 'Test components', completed: false },
+	{ id: '1', title: 'Learn Storybook', completed: false, priority: 'medium' },
+	{ id: '2', title: 'Write stories', completed: true, priority: 'high' },
+	{ id: '3', title: 'Test components', completed: false, priority: 'low' },
 ];
 
 export const Default: Story = {
 	args: {
 		todos: mockTodos,
-		// onSaveTodo uses default arg
+		onToggleTodo: action('onToggleTodo'),
+		onDeleteTodo: action('onDeleteTodo'),
+		onSaveTodo: action('onSaveTodo'),
 	},
 };
 
 export const Empty: Story = {
 	args: {
 		todos: [],
-		// onSaveTodo uses default arg
+		onToggleTodo: action('onToggleTodo'),
+		onDeleteTodo: action('onDeleteTodo'),
+		onSaveTodo: action('onSaveTodo'),
 	},
 };
 
 export const WithTodos: Story = {
 	args: {
 		todos: [
-			{ id: '1', title: 'Learn React', completed: false },
-			{ id: '2', title: 'Build a todo app', completed: true },
-			{ id: '3', title: 'Master TypeScript', completed: false },
+			{ id: '1', title: 'Learn React', completed: false, priority: 'medium' },
+			{ id: '2', title: 'Build a todo app', completed: true, priority: 'high' },
+			{ id: '3', title: 'Master TypeScript', completed: false, priority: 'low' },
 		],
 		// onSaveTodo uses default arg
 	},
@@ -98,12 +103,12 @@ export const WithTodos: Story = {
 export const ManyTodos: Story = {
 	args: {
 		todos: [
-			{ id: '1', title: 'Learn React', completed: false },
-			{ id: '2', title: 'Build a todo app', completed: true },
-			{ id: '3', title: 'Master TypeScript', completed: false },
-			{ id: '4', title: 'Implement new features', completed: false },
-			{ id: '5', title: 'Fix bugs', completed: true },
-			{ id: '6', title: 'Deploy application', completed: false },
+			{ id: '1', title: 'Learn React', completed: false, priority: 'medium' },
+			{ id: '2', title: 'Build a todo app', completed: true, priority: 'high' },
+			{ id: '3', title: 'Master TypeScript', completed: false, priority: 'low' },
+			{ id: '4', title: 'Implement new features', completed: false, priority: 'medium' },
+			{ id: '5', title: 'Fix bugs', completed: true, priority: 'high' },
+			{ id: '6', title: 'Deploy application', completed: false, priority: 'low' },
 		],
 		// onSaveTodo uses default arg
 	},

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+	'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+	{
+		variants: {
+			variant: {
+				default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+				secondary:
+					'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+				destructive:
+					'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+				outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+		},
+	}
+);
+
+function Badge({
+	className,
+	variant,
+	asChild = false,
+	...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+	const Comp = asChild ? Slot : 'span';
+
+	return (
+		<Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+	);
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,226 @@
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+	return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+	return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+	return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+	className,
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+	return (
+		<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Content
+				data-slot="dropdown-menu-content"
+				sideOffset={sideOffset}
+				className={cn(
+					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+					className
+				)}
+				{...props}
+			/>
+		</DropdownMenuPrimitive.Portal>
+	);
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+	return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+	className,
+	inset,
+	variant = 'default',
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+	inset?: boolean;
+	variant?: 'default' | 'destructive';
+}) {
+	return (
+		<DropdownMenuPrimitive.Item
+			data-slot="dropdown-menu-item"
+			data-inset={inset}
+			data-variant={variant}
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuCheckboxItem({
+	className,
+	children,
+	checked,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+	return (
+		<DropdownMenuPrimitive.CheckboxItem
+			data-slot="dropdown-menu-checkbox-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			checked={checked}
+			{...props}
+		>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.CheckboxItem>
+	);
+}
+
+function DropdownMenuRadioGroup({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+	return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+	return (
+		<DropdownMenuPrimitive.RadioItem
+			data-slot="dropdown-menu-radio-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			{...props}
+		>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CircleIcon className="size-2 fill-current" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.RadioItem>
+	);
+}
+
+function DropdownMenuLabel({
+	className,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.Label
+			data-slot="dropdown-menu-label"
+			data-inset={inset}
+			className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+	return (
+		<DropdownMenuPrimitive.Separator
+			data-slot="dropdown-menu-separator"
+			className={cn('bg-border -mx-1 my-1 h-px', className)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+	return (
+		<span
+			data-slot="dropdown-menu-shortcut"
+			className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+	className,
+	inset,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.SubTrigger
+			data-slot="dropdown-menu-sub-trigger"
+			data-inset={inset}
+			className={cn(
+				'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+				className
+			)}
+			{...props}
+		>
+			{children}
+			<ChevronRightIcon className="ml-auto size-4" />
+		</DropdownMenuPrimitive.SubTrigger>
+	);
+}
+
+function DropdownMenuSubContent({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+	return (
+		<DropdownMenuPrimitive.SubContent
+			data-slot="dropdown-menu-sub-content"
+			className={cn(
+				'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuPortal,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuShortcut,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+};

--- a/src/store/todoStore.ts
+++ b/src/store/todoStore.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import { CreateTodoParams, Todo, TodoFilter, TodoState } from '@/types/todoTypes';
+import { CreateTodoParams, PriorityLevel, Todo, TodoFilter, TodoState } from '@/types/todoTypes';
 
 // Fallback for environments without localStorage
 const inMemoryStorage = {
@@ -27,6 +27,7 @@ export const useTodoStore = create<TodoState>()(
 					completed: params.completed ?? false,
 					description: params.description,
 					dueDate: params.dueDate,
+					priority: params.priority ?? 'medium',
 				};
 
 				set(state => ({
@@ -84,6 +85,18 @@ export const useTodoStore = create<TodoState>()(
 
 			setFilter: (filter: TodoFilter): void => {
 				set({ filter });
+			},
+
+			getSortedTodosByPriority: (): Todo[] => {
+				const todos = get().todos;
+				// Define the sort order for priorities
+				const priorityOrder: Record<PriorityLevel, number> = {
+					high: 1,
+					medium: 2,
+					low: 3,
+				};
+				// Create a new sorted array (do not mutate the original state)
+				return [...todos].sort((a, b) => priorityOrder[a.priority] - priorityOrder[b.priority]);
 			},
 
 			reset: () => {

--- a/src/types/todoTypes.ts
+++ b/src/types/todoTypes.ts
@@ -1,9 +1,12 @@
+export type PriorityLevel = 'low' | 'medium' | 'high';
+
 export interface Todo {
 	id: string;
 	title: string;
 	completed: boolean;
 	description?: string;
 	dueDate?: string;
+	priority: PriorityLevel;
 }
 
 export enum TodoFilter {
@@ -17,6 +20,7 @@ export type CreateTodoParams = {
 	completed?: boolean;
 	description?: string;
 	dueDate?: string;
+	priority?: PriorityLevel;
 };
 
 export interface TodoState {
@@ -27,6 +31,7 @@ export interface TodoState {
 	updateTodo: (id: string, updates: Partial<Omit<Todo, 'id'>>) => Todo | null;
 	deleteTodo: (id: string) => Todo | null;
 	setFilter: (filter: TodoFilter) => void;
+	getSortedTodosByPriority: () => Todo[];
 	reset: () => void;
 }
 

--- a/tests/unit/components/AddTodoForm.test.tsx
+++ b/tests/unit/components/AddTodoForm.test.tsx
@@ -39,8 +39,8 @@ describe('AddTodoForm Component', () => {
 			const buttonElement = screen.getByRole('button', { name: /add/i });
 			fireEvent.click(buttonElement);
 
-			// Then: onAddTodo should be called with the entered title
-			expect(mockAddTodo).toHaveBeenCalledWith({ title: 'Test Todo' });
+			// Then: onAddTodo should be called with the entered title and default priority
+			expect(mockAddTodo).toHaveBeenCalledWith({ title: 'Test Todo', priority: 'medium' });
 		});
 
 		it('should not call onAddTodo when form is submitted with empty input', () => {

--- a/tests/unit/components/TodoItem.test.tsx
+++ b/tests/unit/components/TodoItem.test.tsx
@@ -15,12 +15,14 @@ describe('TodoItem Component', () => {
 		id: '1',
 		title: 'Learn React',
 		completed: false,
+		priority: 'medium',
 	};
 
 	const mockCompletedTodo: Todo = {
 		id: '2',
 		title: 'Build a todo app',
 		completed: true,
+		priority: 'high',
 	};
 
 	describe('Initial Rendering', () => {

--- a/tests/unit/components/TodoList.test.tsx
+++ b/tests/unit/components/TodoList.test.tsx
@@ -12,9 +12,9 @@ import { Todo } from '@/types/todoTypes';
  */
 describe('TodoList Component', () => {
 	const mockTodos: Todo[] = [
-		{ id: '1', title: 'Learn React', completed: false },
-		{ id: '2', title: 'Build a todo app', completed: true },
-		{ id: '3', title: 'Master TypeScript', completed: false },
+		{ id: '1', title: 'Learn React', completed: false, priority: 'medium' },
+		{ id: '2', title: 'Build a todo app', completed: true, priority: 'high' },
+		{ id: '3', title: 'Master TypeScript', completed: false, priority: 'low' },
 	];
 
 	describe('Initial Rendering', () => {


### PR DESCRIPTION
## Changes implemented

<!-- List the main components or features implemented -->

- Implement priority handling (low, medium, high) for todos in the store.
- Add priority selection dropdown to the AddTodoForm.
- Display priority level using colored badges in TodoItem.
- Refactor TodoItem action buttons to use shadcn/ui Button component.
- Update Storybook stories for AddTodoForm and TodoItem.

## Tasks completed

<!-- List the tasks completed from the development plan with checkmarks -->

- [x] PRIO-1: Write tests for priority features (add, edit, sort)
- [x] PRIO-2: Extend Todo model with priority levels
- [x] PRIO-3: Implement sorting by priority (in store)
- [x] PRIO-4: Implement priority selector in forms
- [x] PRIO-5: Implement priority display in TodoItem
- [x] PRIO-STORY: Create/Update Storybook stories for AddTodoForm & TodoItem

## Type of change

<!-- Mark the appropriate option(s) with an "x" -->

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring (Icons in TodoItem, style improvements)
- [x] 📝 Documentation (Storybook updates)
- [x] 🔧 Configuration (Added shadcn components: dropdown-menu, badge)

## Quality assurance

<!-- Mark all that apply with an "x" -->

- [x] 🧪 BDD/TDD approach followed (for store logic)
- [x] ✅ Unit tests added/updated (for store priority logic)
- [ ] 🔄 Integration tests added/updated (N/A for this feature scope)
- [x] 📚 Storybook stories updated
- [x] 🧠 Manual testing performed (visual check in Storybook)
- [x] 🔍 All existing tests pass (Verified by pre-commit hook)

## Additional notes

<!-- Any other information that would be useful for reviewers -->

- Priority selection defaults to 'medium' when adding a new todo.
- Further improvement planned: Allow 'undefined' priority.
